### PR TITLE
Support for datetime.timedelta responses

### DIFF
--- a/connexion/decorators/produces.py
+++ b/connexion/decorators/produces.py
@@ -29,6 +29,9 @@ class JSONEncoder(json.JSONEncoder):
 
         if isinstance(o, datetime.date):
             return o.isoformat()
+        
+        if isinstance(o, datetime.timedelta):
+            return (datetime.datetime.min + o).time().isoformat()
 
         return json.JSONEncoder.default(self, o)
 


### PR DESCRIPTION
Fixes #326

Changes proposed in this pull request:

Fixes an issue where timedelta objects returned by the DB throw an error "TypeError: datetime.timedelta() is not JSON serializable" by converting to a time in isoformat
